### PR TITLE
JDP200801-1: Implemented ProductController endpoints with dummy data return via ProductDtoStub class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,26 @@ repositories {
 
 
 dependencies {
+    // SPRING BOOT
+    // Database
     implementation('org.springframework.boot:spring-boot-starter-data-jpa')
+
+    // Web
     implementation('org.springframework.boot:spring-boot-starter-web')
-    runtimeOnly('com.h2database:h2')
+
+    // Unit tests
     testImplementation('org.springframework.boot:spring-boot-starter-test')
+
+    // OTHER
+    // MySQL database driver
+    runtimeOnly('mysql:mysql-connector-java')
+
+    // H2 Database
+    runtimeOnly('com.h2database:h2')
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok:1.18.12'
+    annotationProcessor 'org.projectlombok:lombok:1.18.12'
+    testCompileOnly 'org.projectlombok:lombok:1.18.12'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.12'
 }

--- a/src/main/java/com/kodilla/ecommercee/ProductController.java
+++ b/src/main/java/com/kodilla/ecommercee/ProductController.java
@@ -1,4 +1,0 @@
-package com.kodilla.ecommercee;
-
-public class ProductController {
-}

--- a/src/main/java/com/kodilla/ecommercee/controller/ProductController.java
+++ b/src/main/java/com/kodilla/ecommercee/controller/ProductController.java
@@ -1,0 +1,42 @@
+package com.kodilla.ecommercee.controller;
+
+import com.kodilla.ecommercee.domain.product.ProductDtoStub;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@RestController
+@RequestMapping("/v1/product")
+public class ProductController {
+
+    @RequestMapping(method = RequestMethod.GET, value = "getProducts")
+    public List<ProductDtoStub> getAllProducts() {
+        return IntStream.range(0, 10)
+                .mapToObj(e -> new ProductDtoStub((long) e, "TestProduct" + e))
+                .collect(Collectors.toList());
+    }
+
+    @RequestMapping(method = RequestMethod.GET, value = "getProduct")
+    public ProductDtoStub getProducts(@RequestParam long productId) {
+        return new ProductDtoStub(productId, "TestProduct" + productId);
+    }
+
+    @RequestMapping(method = RequestMethod.POST, value = "createProduct", consumes = APPLICATION_JSON_VALUE)
+    public ProductDtoStub createProduct(@RequestBody ProductDtoStub productDtoStub) {
+        return productDtoStub;
+    }
+
+    @RequestMapping(method = RequestMethod.PUT, value = "updateProduct", consumes = APPLICATION_JSON_VALUE)
+    public ProductDtoStub updateProduct(@RequestBody ProductDtoStub productDtoStub) {
+        return productDtoStub;
+    }
+
+    @RequestMapping(method = RequestMethod.DELETE, value = "deleteProduct")
+    public boolean deleteProduct(@RequestParam Long productId) {
+        return true;
+    }
+}

--- a/src/main/java/com/kodilla/ecommercee/domain/product/ProductDtoStub.java
+++ b/src/main/java/com/kodilla/ecommercee/domain/product/ProductDtoStub.java
@@ -1,0 +1,12 @@
+package com.kodilla.ecommercee.domain.product;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProductDtoStub {
+    // This is just a placeholder class, in absence of solidified Product entity, and its DTO.
+    private Long id;
+    private String name;
+}


### PR DESCRIPTION
**Major:**
- Implemented ProductController endpoints with dummy data return via ProductDtoStub class
- Created ProductDtoStub, for easy dummy data return from ProductController first-pass implementation

**Minor:**
- Created 'controller' & 'domain.product' packages inside com.kodilla.ecommercee. 
- Moved ProductController into 'controler' package, 
- Moved 'ProductDtoStub' class into 'domain.product' package.

**Gradle:**
- Added MySQL driver to gradle.build
- Added Lombok to gradle.build